### PR TITLE
FRONTEND PR 1: chore(frontend): add Next.js frontend workspace and docker-compose integration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -140,5 +140,21 @@ services:
     depends_on:
       - kafka-service
 
+  frontend:
+    build:
+      context: ./services/frontend
+      dockerfile: ./services/frontend/Dockerfile
+    container_name: frontend
+    environment:
+      - NODE_ENV=development
+      - API_BASE_URL=http://product-service:8080
+    ports:
+      - "3000:3000"
+    depends_on:
+      product-service:
+        condition: service_healthy
+      order-service:
+        condition: service_healthy
+
 volumes:
   postgres_data:

--- a/services/frontend/Dockerfile
+++ b/services/frontend/Dockerfile
@@ -1,0 +1,26 @@
+FROM node:20-alpine AS base
+WORKDIR /app
+
+# Install pnpm
+RUN npm install -g pnpm
+
+FROM base AS deps
+COPY package.json pnpm-workspace.yaml ./
+COPY apps/web/package.json ./apps/web/
+COPY packages/ui/package.json ./packages/ui/
+RUN pnpm install --frozen-lockfile --prod=false
+
+FROM base AS builder
+COPY . .
+RUN pnpm -w --filter apps/web build
+
+FROM node:20-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=builder /app/apps/web/.next ./.next
+COPY --from=builder /app/apps/web/public ./public
+COPY --from=builder /app/apps/web/package.json ./package.json
+RUN npm install -g pnpm && pnpm install --prod
+EXPOSE 3000
+WORKDIR /app
+CMD ["pnpm", "start"]

--- a/services/frontend/README.md
+++ b/services/frontend/README.md
@@ -1,0 +1,29 @@
+# Frontend (Next.js) workspace
+
+This folder contains the frontend Next.js application and shared UI packages.
+
+Getting started (local dev):
+
+1. Install pnpm (if not already):
+
+```bash
+npm install -g pnpm
+```
+
+2. Install dependencies and start dev server:
+
+```bash
+cd services/frontend
+pnpm install
+pnpm dev
+```
+
+Dev via docker-compose (with backend services):
+
+```bash
+# from repo root
+docker-compose -f docker-compose.yml -f services/frontend/docker-compose.override.yml up --build
+```
+
+Notes:
+- This is an initial scaffold. API client generation and Tailwind setup will be added in follow-up PRs.

--- a/services/frontend/apps/web/next.config.mjs
+++ b/services/frontend/apps/web/next.config.mjs
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    appDir: true
+  }
+}
+
+export default nextConfig

--- a/services/frontend/apps/web/package.json
+++ b/services/frontend/apps/web/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "web",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "next dev -p 3000",
+    "build": "next build",
+    "start": "next start -p 3000",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.4.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  }
+}

--- a/services/frontend/apps/web/src/app/globals.css
+++ b/services/frontend/apps/web/src/app/globals.css
@@ -1,0 +1,7 @@
+html, body, #__next {
+  height: 100%;
+}
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial;
+}

--- a/services/frontend/apps/web/src/app/layout.tsx
+++ b/services/frontend/apps/web/src/app/layout.tsx
@@ -1,0 +1,16 @@
+import './globals.css'
+
+export const metadata = {
+  title: 'Microservices Frontend',
+  description: 'Frontend scaffold for microservices-project'
+}
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <main>{children}</main>
+      </body>
+    </html>
+  )
+}

--- a/services/frontend/apps/web/src/app/page.tsx
+++ b/services/frontend/apps/web/src/app/page.tsx
@@ -1,0 +1,15 @@
+export default function Home() {
+  return (
+    <div style={{ padding: 24 }}>
+      <h1>Microservices Frontend (scaffold)</h1>
+      <p>
+        This is a placeholder Next.js app. Pages to add: Home / Catalog, Product details,
+        Order status.
+      </p>
+      <ul>
+        <li><a href="/product/1">Product details (sample)</a></li>
+        <li><a href="/order/1">Order status (sample)</a></li>
+      </ul>
+    </div>
+  )
+}

--- a/services/frontend/apps/web/tsconfig.json
+++ b/services/frontend/apps/web/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/services/frontend/docker-compose.override.yml
+++ b/services/frontend/docker-compose.override.yml
@@ -1,0 +1,19 @@
+version: '3.8'
+services:
+  frontend:
+    build:
+      context: ./services/frontend
+      dockerfile: ./services/frontend/Dockerfile
+    container_name: frontend-dev
+    environment:
+      - NODE_ENV=development
+      - API_BASE_URL=http://product-service:8080
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./services/frontend:/app
+      - /app/node_modules
+    command: pnpm dev
+    depends_on:
+      - product-service
+      - order-service

--- a/services/frontend/package.json
+++ b/services/frontend/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "microservices-frontend",
+  "private": true,
+  "version": "0.1.0",
+  "workspaces": [
+    "apps/*",
+    "packages/*"
+  ],
+  "scripts": {
+    "dev": "pnpm --filter apps/web dev",
+    "build": "pnpm --filter apps/web build",
+    "start": "pnpm --filter apps/web start",
+    "generate:api": "node ./scripts/generate-api-client.js || echo 'generate:api placeholder'"
+  }
+}

--- a/services/frontend/packages/api-client/README.md
+++ b/services/frontend/packages/api-client/README.md
@@ -1,0 +1,5 @@
+This package will contain the generated TypeScript API client (OpenAPI generated).
+
+During CI we will generate code into `packages/api-client/src` and publish it to the workspace.
+
+For local development you can either commit generated sources or run the generation script in the workspace.

--- a/services/frontend/packages/api-client/package.json
+++ b/services/frontend/packages/api-client/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@ms/api-client",
+  "version": "0.0.1",
+  "private": true,
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "files": ["src"]
+}

--- a/services/frontend/packages/ui/package.json
+++ b/services/frontend/packages/ui/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@ms/ui",
+  "version": "0.0.1",
+  "private": true,
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "files": ["src"]
+}

--- a/services/frontend/packages/ui/src/index.ts
+++ b/services/frontend/packages/ui/src/index.ts
@@ -1,0 +1,7 @@
+export const Button = ({ children }: { children: string }) => {
+  return (
+    // minimal button placeholder
+    // eslint-disable-next-line react/button-has-type
+    <button style={{ padding: '8px 12px', borderRadius: 6 }}>{children}</button>
+  )
+}

--- a/services/frontend/packages/ui/src/index.tsx
+++ b/services/frontend/packages/ui/src/index.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+
+export const Button: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  return (
+    <button type="button" style={{ padding: '8px 12px', borderRadius: 6 }}>
+      {children}
+    </button>
+  )
+}
+
+export default Button

--- a/services/frontend/pnpm-workspace.yaml
+++ b/services/frontend/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - 'apps/*'
+  - 'packages/*'


### PR DESCRIPTION
Summary
Adds a lightweight Next.js frontend workspace under [frontend](vscode-file://vscode-app/Users/heliconmuse/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) and integrates a frontend service into the root [docker-compose.yml](vscode-file://vscode-app/Users/heliconmuse/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html). This is a scaffold only (App Router, TypeScript config, minimal UI package placeholder, and API-client placeholder). It prepares the repo for follow-up work: Tailwind, Storybook, OpenAPI client generation and feature pages.

What this PR contains

New workspace: [frontend](vscode-file://vscode-app/Users/heliconmuse/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
package.json (workspace root) and pnpm-workspace.yaml
[README.md](vscode-file://vscode-app/Users/heliconmuse/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) with basic dev instructions
Dockerfile (multi-stage) for production builds
docker-compose.override.yml for dev mode (mounts source, runs pnpm dev)
apps/web/ — minimal Next.js app (App Router)
package.json, next.config.mjs, tsconfig.json
src/app/layout.tsx, src/app/page.tsx, src/app/globals.css
packages/ui/ — placeholder UI package (exports a simple Button component)
packages/api-client/ — placeholder package for generated OpenAPI client
Updated root [docker-compose.yml](vscode-file://vscode-app/Users/heliconmuse/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html): adds frontend service that depends on product-service and order-service so the frontend runs in the compose network and can call backend services in dev.

How to test locally

Install pnpm (if you don't have it):
Run the frontend app (dev mode):
Or run the full compose stack (frontend + backend):
Verify:

Home page ([http://localhost:3000](vscode-file://vscode-app/Users/heliconmuse/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)) loads and displays the scaffold text and sample links (/product/1, /order/1).
From inside the frontend container (or via dev server), the frontend can reach backend services on the compose network (e.g., http://product-service:8080). For a quick smoke check, visit the frontend and ensure product-service-driven pages render once the backend is up.

Checklist

 pnpm dev boots the Next.js app locally
 docker-compose builds and runs the frontend container and it can reach backend services
 PR targets develop (not main) and has at least one reviewer
Follow-up PRs (planned)

Add Tailwind CSS + global design tokens and theming.
Add Storybook and core UI components in [ui](vscode-file://vscode-app/Users/heliconmuse/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html).
Add OpenAPI generation script and generated TypeScript client in [api-client](vscode-file://vscode-app/Users/heliconmuse/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html).
Implement product list and product detail pages wired to product-service (using generated client + React Query).
Add GitHub Actions jobs for: lint, tests, API-client generation, and build.