### PR TITLE
Enable payment recovery scheduling

### DIFF
--- a/services/payment-service/src/main/java/nik/kalomiris/payment_service/PaymentServiceApplication.java
+++ b/services/payment-service/src/main/java/nik/kalomiris/payment_service/PaymentServiceApplication.java
@@ -3,12 +3,14 @@ package nik.kalomiris.payment_service;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 /**
  * Main entry point for the payment service application.
  */
 @SpringBootApplication
 @ComponentScan(basePackages = { "nik.kalomiris" })
+@EnableScheduling
 public class PaymentServiceApplication {
 
     public static void main(String[] args) {

--- a/services/payment-service/src/test/java/nik/kalomiris/payment_service/service/PaymentRetryConfigTest.java
+++ b/services/payment-service/src/test/java/nik/kalomiris/payment_service/service/PaymentRetryConfigTest.java
@@ -1,10 +1,12 @@
 package nik.kalomiris.payment_service.service;
 
 import nik.kalomiris.payment_service.provider.dto.FailureType;
+import nik.kalomiris.payment_service.PaymentServiceApplication;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.context.properties.bind.Bindable;
 import org.springframework.boot.context.properties.bind.Binder;
 import org.springframework.boot.context.properties.source.MapConfigurationPropertySource;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.retry.support.RetryTemplate;
 
 import java.util.Map;
@@ -83,5 +85,10 @@ class PaymentRetryConfigTest {
             throw new IllegalStateException("always fail");
         }));
         assertEquals(3, attempts.get());
+    }
+
+    @Test
+    void applicationEnablesScheduling() {
+        assertTrue(PaymentServiceApplication.class.isAnnotationPresent(EnableScheduling.class));
     }
 }


### PR DESCRIPTION
`PaymentRecoveryJob` was annotated with `@Scheduled`, but the payment service never enabled scheduling, so pending authorizations could not be retried in production.

This change enables scheduling at the application entrypoint and adds a regression test that asserts the application class carries `@EnableScheduling`.

**Validation**
- `mvn -pl services/payment-service -am test --no-transfer-progress`